### PR TITLE
Fix Turkish format placeholder in CSV import success string

### DIFF
--- a/strings.json
+++ b/strings.json
@@ -1533,7 +1533,7 @@
     "es": "Se importaron correctamente %s cotizaciones y %s acciones",
     "de": "Erfolgreich importierte %s Bestände und %s Notierungen",
     "fr": "Importation réussie de %s cours et %s positions",
-    "tr": "%S Öneriler ve %s Varlıklar içe aktarıldı",
+    "tr": "%s Öneriler ve %s Varlıklar içe aktarıldı",
     "zh-Hant-TW": "成功匯入 %s 筆報價與 %s 筆持股",
     "zh-Hans": "成功导入 %s 条报价和 %s 条持股记录"
   },


### PR DESCRIPTION
### Motivation
- Correct a malformed format placeholder in the Turkish translation to prevent formatting/runtime issues when displaying CSV import success messages.

### Description
- Replace the incorrect `%S` placeholder with `%s` for the `csvImport_importedQuotesAndHoldingsFormatted` Turkish translation in `strings.json`.

### Testing
- Ran localization string linting and the unit test suite and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b610044e508325ae9b527e1d3c7388)