### PR TITLE
Update README translation counts from strings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 This repository contains translations for the My Stocks Portfolio (MSP) application.
 
-Progress (1042 strings):
+Progress (1050 strings):
 
-1046/1046 - English
+1050/1050 - English
 
-957/1046 - German
+1050/1050 - German
 
-802/1046 - Spanish
+1050/1050 - Spanish
 
-965/1046 - Turkish
+1048/1050 - Turkish
 
-1046/1046 - Traditional Chinese
+1048/1050 - Traditional Chinese
 
-1046/1046 - Simplified Chinese
+1050/1050 - Simplified Chinese
 
-548/1046 - French
+1050/1050 - French
 
 To make translation suggestions, you can edit the localization file [strings.json](https://github.com/mystocksportfolio/translations/blob/main/strings.json) (see screenshots below). If your language is not listed yet, you may add a new entry for your language.
 


### PR DESCRIPTION
### Motivation
- Keep the README translation progress accurate by reflecting the current number of translated strings per language as derived from the authoritative `strings.json` file.

### Description
- Recalculated totals (excluding the `example` block) and updated the README progress header to `Progress (1050 strings)` and each language line to match the `strings.json` data. 
- New displayed counts are: English 1050/1050, German 1050/1050, Spanish 1050/1050, Turkish 1048/1050, Traditional Chinese 1048/1050, Simplified Chinese 1050/1050, French 1050/1050.
- Noted the only missing translation keys are `generic_placeholderAndPlaceholder` and `generic_placeholderAndPlaceholderNoSpace` for `tr` and `zh-Hant-TW`.

### Testing
- Ran a script that parses `strings.json` to count present translations per language and confirmed the updated counts, which succeeded. 
- Ran a second script to enumerate missing keys for `tr` and `zh-Hant-TW` and confirmed the two missing keys, which succeeded. 
- Verified the README file content reflects the new counts via a file diff check, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b67e7ed6c8832599318d14de26cada)