### PR TITLE
Complete remaining Turkish and Traditional Chinese translation entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Progress (1050 strings):
 
 1050/1050 - Spanish
 
-1048/1050 - Turkish
+1050/1050 - Turkish
 
-1048/1050 - Traditional Chinese
+1050/1050 - Traditional Chinese
 
 1050/1050 - Simplified Chinese
 

--- a/strings.json
+++ b/strings.json
@@ -3404,7 +3404,9 @@
     "de": "%s %s",
     "zh-Hans": "%s %s",
     "es": "%s %s",
-    "fr": "%s %s"
+    "fr": "%s %s",
+    "tr": "%s %s",
+    "zh-Hant-TW": "%s %s"
   },
   "generic_placeholderAndPlaceholderNoSpace": {
     "_formatted": false,
@@ -3414,7 +3416,9 @@
     "de": "%s%s",
     "zh-Hans": "%s%s",
     "es": "%s%s",
-    "fr": "%s%s"
+    "fr": "%s%s",
+    "tr": "%s%s",
+    "zh-Hant-TW": "%s%s"
   },
   "generic_placeholderInBrackets": {
     "_formatted": false,


### PR DESCRIPTION
### Motivation
- Ensure translation coverage is complete for Turkish (`tr`) and Traditional Chinese (`zh-Hant-TW`) by adding the two missing placeholder formatting entries and updating the progress display. 

### Description
- Added `tr` and `zh-Hant-TW` values for `generic_placeholderAndPlaceholder` and `generic_placeholderAndPlaceholderNoSpace` in `strings.json`. 
- Updated the progress lines in `README.md` so Turkish and Traditional Chinese now show `1050/1050`.

### Testing
- Ran a Python check (`python - <<'PY' ...`) to verify both `tr` and `zh-Hant-TW` are non-empty for all 1050 strings, which returned `1050` for each. 
- Inspected the changes with `git diff -- README.md strings.json` to confirm the expected modifications to `README.md` and `strings.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b683dd4ad0832586e36f3baf470d38)