### PR TITLE
Fix malformed escape characters in strings.json Turkish translations

### DIFF
--- a/strings.json
+++ b/strings.json
@@ -4790,7 +4790,7 @@
     "de": "Konzernbeteiligung an 'Anderen', wenn weniger als % des Gesamtbetrags",
     "fr": "Grouper les position sous 'Autres' quand ils représentent moins que % du total",
     "fr-CA": "Grouper les position sous 'Autres' quand ils représentent moins que % du total",
-    "tr": "Toplamın %'sinden az ise varlıkların 'Diğerleri\\ grubundaki payı",
+    "tr": "Toplamın %'sinden az ise varlıkların 'Diğerleri' grubundaki payı",
     "zh-Hant-TW": "低於此百分比的持股將會歸類到'其他'",
     "zh-Hans": "占比低于 % 时归类为“其他”"
   },
@@ -7442,7 +7442,7 @@
     "de": "Das Abonnement ist aktiv.\\n\\nVielen Dank für Ihr Abonnement!",
     "fr": "La souscription est active\\n\\nMerci d'avoir souscrit !",
     "fr-CA": "La souscription est active\\n\\nMerci d'avoir souscrit !",
-    "tr": "Abonelik aktif\\n\\Abone olduğunuz için teşekkürler!",
+    "tr": "Abonelik aktif\\n\\nAbone olduğunuz için teşekkürler!",
     "zh-Hant-TW": "訂閱已啟用\\n\\n感謝您的訂閱！",
     "zh-Hans": "订阅已激活\\n\\n感谢您的订阅！"
   },


### PR DESCRIPTION
### Motivation
- Correct invalid JSON escape usage in Turkish translations to prevent malformed strings and ensure newline behavior matches other locales.

### Description
- Update `strings.json` to remove an unintended backslash in `portfolioAllocations_groupInOthers.tr` and to replace the invalid `"\Abone"` sequence with a proper escaped newline in `purchases_subscriptionActive.tr` so the entries read `"Toplamın %'sinden az ise varlıkların 'Diğerleri' grubundaki payı"` and `"Abonelik aktif\\n\\nAbone olduğunuz için teşekkürler!"` respectively.

### Testing
- Parsed `strings.json` using `json.loads()` successfully with no errors. 
- Ran a regex scan for invalid JSON escape sequences `\\([^"\\/bfnrtu])` and confirmed zero matches remaining.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b6853baee08325bedfcda3039920d4)